### PR TITLE
Pin Node.js 24.x via engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "pokedex",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "24.x"
+  },
   "dependencies": {
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",


### PR DESCRIPTION
## Resumo

Fixa a versão do Node no `package.json` (`"engines": { "node": "24.x" }`) para corrigir o erro de deploy:

> Found invalid or discontinued Node.js Version: "16.x". Please set Node.js Version to 24.x.

O `16.x` estava definido no **dashboard da plataforma** (Vercel), não no repositório. Este pin versiona a escolha; ainda assim, ajuste a **Node.js Version para 24.x em Settings → Build & Deployment** e refaça o deploy.

## Nota
- `react-scripts@5` (webpack 5) builda em Node 24 sem flags extras.
- Localmente (Node 22) o `engines` só emite aviso, não bloqueia `npm install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)